### PR TITLE
Prevent shared todo duplicate

### DIFF
--- a/src/main/java/uhbp/todolist/Service/ShareServiceImple.java
+++ b/src/main/java/uhbp/todolist/Service/ShareServiceImple.java
@@ -69,13 +69,19 @@ public class ShareServiceImple implements ShareService {
             Member selectedMember = findById(memberId);
             log.info("선택된 회원의 정보 = {}", selectedMember);
 
-            // 팩토리를 통해 Entity 생성
-            TodoShareApproveQueue shareTodo = TodoShareApproveQueue.todoShareApproveQueueFactory(todo, selectedMember, loginMember, LocalDate.now());
-            // 위에서 생성한 Entity를 DB에 저장
-            shareRepository.save(shareTodo);
+            // 이미 공유된 todo인지 확인 (alert창 따로 빼면 좋을텐데 더 좋은 방법 없을까)
+            List<TodoShareApproveQueue> approveAlready = shareRepository.findAlreadyShare(todo, loginMember, selectedMember);
+            List<TodoMemberManage> todoAlready = memberManageRepository.findAlreadyShareTodo(todo, selectedMember);
 
-            // sse 알림 (공유받는 사용자의 index 넘겨서 해당 사용자의 emitter에 알림 이벤트 발행)
-            alarmService.alarmShareEvent(selectedMember.getMemberIndex());
+            if(approveAlready.isEmpty() && todoAlready.isEmpty()){
+                // 팩토리를 통해 Entity 생성
+                TodoShareApproveQueue shareTodo = TodoShareApproveQueue.todoShareApproveQueueFactory(todo, selectedMember, loginMember, LocalDate.now());
+                // 위에서 생성한 Entity를 DB에 저장
+                shareRepository.save(shareTodo);
+
+                // sse 알림 (공유받는 사용자의 index 넘겨서 해당 사용자의 emitter에 알림 이벤트 발행)
+                alarmService.alarmShareEvent(selectedMember.getMemberIndex());
+            }
         }
     }
 

--- a/src/main/java/uhbp/todolist/repository/CustomRepository.java
+++ b/src/main/java/uhbp/todolist/repository/CustomRepository.java
@@ -2,6 +2,8 @@ package uhbp.todolist.repository;
 
 import uhbp.todolist.domain.Member;
 import uhbp.todolist.domain.TodoList;
+import uhbp.todolist.domain.TodoMemberManage;
+import uhbp.todolist.domain.TodoShareApproveQueue;
 
 import java.util.List;
 
@@ -16,4 +18,7 @@ public interface CustomRepository {
 
     List<TodoList> findSharedTodoListsByMember(String memberId);
 
+    List<TodoShareApproveQueue> findAlreadyShare(TodoList todo, Member loginMember, Member selectedMember);
+
+    List<TodoMemberManage> findAlreadyShareTodo(TodoList todo, Member selectedMember);
 }

--- a/src/main/java/uhbp/todolist/repository/CustomRepositoryImpl.java
+++ b/src/main/java/uhbp/todolist/repository/CustomRepositoryImpl.java
@@ -12,6 +12,8 @@ import java.time.LocalDate;
 import java.util.List;
 
 import static uhbp.todolist.domain.QMember.member;
+import static uhbp.todolist.domain.QTodoShareApproveQueue.todoShareApproveQueue;
+import static uhbp.todolist.domain.QTodoMemberManage.todoMemberManage;
 
 @Repository
 @Transactional
@@ -94,6 +96,33 @@ public class CustomRepositoryImpl implements CustomRepository {
                 .where(qTodoMemberManage.member.memberId.eq(memberId)  // 공유 받는 할일 목록
                          .or(qTodoList.member.memberId.eq(memberId)))  // 공유 해준 할일 목록
                 .orderBy(qTodoList.todoIspinned.desc(), qTodoList.todoGendate.asc())
+                .fetch();
+    }
+
+    @Override
+    public List<TodoShareApproveQueue> findAlreadyShare(TodoList todo, Member loginMember, Member selectedMember) {
+        JPAQueryFactory queryFactory = new JPAQueryFactory(em);
+
+        return queryFactory
+                .selectFrom(todoShareApproveQueue)
+                .where(
+                        todoShareApproveQueue.todoIndex.eq(todo),
+                        todoShareApproveQueue.shareMemberIndex.eq(loginMember),
+                        todoShareApproveQueue.sharedMemberIndex.eq(selectedMember)
+                )
+                .fetch();
+    }
+
+    @Override
+    public List<TodoMemberManage> findAlreadyShareTodo(TodoList todo, Member selectedMember) {
+        JPAQueryFactory queryFactory = new JPAQueryFactory(em);
+
+        return queryFactory
+                .selectFrom(todoMemberManage)
+                .where(
+                        todoMemberManage.todoList.eq(todo),
+                        todoMemberManage.member.eq(selectedMember)
+                )
                 .fetch();
     }
 

--- a/src/main/java/uhbp/todolist/repository/TodoMemberManageRepository.java
+++ b/src/main/java/uhbp/todolist/repository/TodoMemberManageRepository.java
@@ -5,5 +5,5 @@ import org.springframework.stereotype.Repository;
 import uhbp.todolist.domain.TodoMemberManage;
 
 @Repository
-public interface TodoMemberManageRepository extends JpaRepository<TodoMemberManage, Long> {
+public interface TodoMemberManageRepository extends JpaRepository<TodoMemberManage, Long>, CustomRepository {
 }

--- a/src/main/java/uhbp/todolist/repository/TodoShareApproveQueueRepository.java
+++ b/src/main/java/uhbp/todolist/repository/TodoShareApproveQueueRepository.java
@@ -8,6 +8,6 @@ import uhbp.todolist.domain.TodoShareApproveQueue;
 import java.util.List;
 
 @Repository
-public interface TodoShareApproveQueueRepository extends JpaRepository<TodoShareApproveQueue, Long> {
+public interface TodoShareApproveQueueRepository extends JpaRepository<TodoShareApproveQueue, Long>, CustomRepository {
     List<TodoShareApproveQueue> findBySharedMemberIndex(Member loginMember);
 }


### PR DESCRIPTION
1️⃣ ApproveQueue 테이블과 MemberManage 테이블에 이미 있는 todo이면 추가로 save 되지않도록 구현 2️⃣ 위와 같은 경우, 이미 공유된 todo라고 띄우고 싶은데 공유대상을 여러명 선택해서 요청 보낸 경우 문제 발생